### PR TITLE
remove obsolete check

### DIFF
--- a/source/bringauto/osm/Route.cpp
+++ b/source/bringauto/osm/Route.cpp
@@ -176,10 +176,6 @@ std::vector<std::shared_ptr<Point>> Route::getStops() {
 }
 
 void Route::compareStations(std::vector<Station> commandStations) {
-	if(commandStations.size() != stops_.size()) {
-		logging::Logger::logError("There isn't the same number of stops in the command ({}) as on the route ({})", commandStations.size(), stops_.size());
-		return;
-	}
 	for(auto commandStation : commandStations) {
 		bool stationFound = false;
 		for(const auto &stop: stops_) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of station comparisons by allowing the system to process command stations regardless of their count relative to stops, enhancing overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->