### PR TITLE
bump fleet-protocol-interface to v2.1.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -8,7 +8,7 @@ BA_PACKAGE_LIBRARY(statesmurf                     v2.2.0)
 BA_PACKAGE_LIBRARY(modbuspp                       v0.3.1 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(nlohmann-json                  v3.10.5 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(fleet-protocol-internal-client v1.1.1)
-BA_PACKAGE_LIBRARY(fleet-protocol-interface       v2.0.0 NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface       v2.1.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(boost                          v1.86.0)
 # All packages needed by libosmium for xml parsing
 BA_PACKAGE_LIBRARY(zlib                           v1.2.11)


### PR DESCRIPTION
`fleet-protocol-interface v2.0.0` was removed from the gitea package repository; only `v2.1.0` remains, so the dependency download fails at CMake configure. Bumping the pin to v2.1.0.